### PR TITLE
Fix position to user's code

### DIFF
--- a/src/ecx/macro/ClassMacroTools.hx
+++ b/src/ecx/macro/ClassMacroTools.hx
@@ -34,7 +34,7 @@ class ClassMacroTools {
 
 	public static function allocComponent<T:Component>(componentClass:ExprOf<Class<T>>):ExprOf<T> {
 		var tp = MacroUtil.getConstTypePath(componentClass);
-		return macro @:privateAccess new $tp();
+		return macro @:privateAccess @:pos($v{componentClass.pos}) new $tp();
 	}
 }
 


### PR DESCRIPTION
We have a problem if `componentClass` type is not found or have some errors. Then the position of "type not found"-error will be `Haxelibs/ecx/0,0,4/src/ecx/macro/ClassMacroTools.hx:27: characters 31-40 : Type not found : AnyInvalidType` but expected a real position in User's code.

See example:

``` haxe
import ecx.Engine;
import ecx.WorldConfig;
class Main
{
    public static function main():Void
    {
        var config = new WorldConfig();
        var world = Engine.initialize().createWorld(config, 1000);
        var game = world.create();
        world.edit(game).create(AnyInvalidType); // <-- error should be there but was in ecx/macro/ClassMacroTools.hx
    }
}
```

Run: `haxe -main Main -lib pcx -dce no -x test`

---

After this fix the error will be there:

`Main.hx:10: characters 26-40 : Type not found : AnyInvalidType`
