### PR TITLE
Update SystemBuilder.hx

### DIFF
--- a/src/ecx/macro/AutoCompBuilder.hx
+++ b/src/ecx/macro/AutoCompBuilder.hx
@@ -26,7 +26,7 @@ class AutoCompBuilder {
 		var fields = Context.getBuildFields();
 		var localClass:ClassType = Context.getLocalClass().get();
 		localClass.meta.add(":final", [], pos);
-
+		
 		buildDefaultConstructor(fields);
 
 		var dataType:Type = localClass.superClass.params[0];
@@ -76,6 +76,20 @@ class AutoCompBuilder {
 							none: macro 0.0,
 							def: macro 0.0,
 							primitive: true
+						};
+					case "Int":
+						return {
+							none: macro 0,
+							def: macro 0,
+							primitive: true,
+							storage: { pack: ["ecx", "ds"], name: "CInt32Array" }
+						};
+					case "UInt":
+						return {
+							none: macro 0,
+							def: macro 0,
+							primitive: true,
+							storage: { pack: ["ecx", "ds"], name: "CInt32Array" }
 						};
 				}
 				throw ("Unhandled Abstract: " + x);

--- a/src/ecx/macro/SystemBuilder.hx
+++ b/src/ecx/macro/SystemBuilder.hx
@@ -123,7 +123,7 @@ class SystemBuilder {
 					}
 					field.meta.push({
 						name: ":unreflective",
-						pos: field.pos
+						pos: Context.currentPos()
 					});
 			}
 		}


### PR DESCRIPTION
Fixed typehinting issue  (caused by overlapping metadata `:unreflective` position) for Haxe 3.4 within `update()` function field body of System classes.

Reference issue: https://github.com/eliasku/ecx/issues/11